### PR TITLE
fix: set sidecarEnabled as false

### DIFF
--- a/adot-helm-eks-ec2/values.yaml
+++ b/adot-helm-eks-ec2/values.yaml
@@ -315,7 +315,7 @@ adotCollector:
       extensions: ["health_check"]
 
   sidecar:
-    enabled: true
+    enabled: false
     name: "adot-sidecar"
     namespace: "adot-sidecar-namespace"
     namespaceOverride: ""


### PR DESCRIPTION
Since our goal is to deploy ADOT Collector as DaemonSet, change the value sidecar.enabled as False.
We'll guide this optional configuration in README.md