### PR TITLE
remove kubeval flag ignore missing schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 REPO_ROOT ?= $(shell git rev-parse --show-toplevel)
-BUILD_DIR ?= $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))/build
-
-$(shell mkdir -p ${BUILD_DIR})
 
 .PHONY:all
 all: validate lint

--- a/scripts/validate-charts.sh
+++ b/scripts/validate-charts.sh
@@ -10,7 +10,7 @@ export PATH="${TOOLS_DIR}:${PATH}"
 FAILED_V3=()
 
 echo "Chart validation ${CHART_DIR} with Helm v3"
-helmv3 template ${CHART_DIR} | kubeval --strict --ignore-missing-schemas || FAILED_V3+=("${CHART_DIR}")
+helmv3 template ${CHART_DIR} | kubeval || FAILED_V3+=("${CHART_DIR}")
 
 if  [[ "${#FAILED_V3[@]}" -eq 0 ]]; then
     echo "All charts passed validation tests!"


### PR DESCRIPTION
This PR is to remove the `kubeval` flag `--ignore-missing-schemas` as our Helm chart does not require resource validations with Custom Resource Definitions (CRDs). 